### PR TITLE
Detach the tab group from the browser tab when the user closes it

### DIFF
--- a/src/components/popup.tsx
+++ b/src/components/popup.tsx
@@ -43,9 +43,9 @@ export class Popup extends React.Component {
   }
 
   private async canCreateTabGroup(browserTab: chrome.tabs.Tab): Promise<boolean> {
-    const isNotAssigned = !await this.storage.isBrowserTabAssigned(browserTab.id);
+    const isAttached = !await this.storage.isBrowserTabAttached(browserTab.id);
     const isValidName = this.state.name !== '';
-    return isNotAssigned && isValidName;
+    return isAttached && isValidName;
   }
 
   private async createTabGroup(browserTab: chrome.tabs.Tab) {

--- a/src/components/tab-bar.tsx
+++ b/src/components/tab-bar.tsx
@@ -25,7 +25,7 @@ export class TabBar extends React.Component {
 
   private getTabId(): Promise<number> {
     return new Promise((resolve, reject) => {
-      chrome.runtime.sendMessage({ type: MessageType.CREATE_TAB }, tabId => {
+      chrome.runtime.sendMessage({ type: MessageType.GET_TAB_ID }, tabId => {
         resolve(tabId);
       });
     });

--- a/src/enums/message-type.ts
+++ b/src/enums/message-type.ts
@@ -1,4 +1,4 @@
 export enum MessageType {
-  CREATE_TAB,
+  GET_TAB_ID,
   NAVIGATE
 };

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -35,7 +35,7 @@ export default class Storage {
     return tabGroup;
   }
 
-  async isBrowserTabAssigned(browserTabId: number) {
+  async isBrowserTabAttached(browserTabId: number) {
     const tabsGroups = await this.getTabsGroup();
     const isAssigned = tabsGroups.some(tabGroup => tabGroup.tabId === browserTabId);
     return isAssigned;
@@ -46,6 +46,13 @@ export default class Storage {
     const tabGroup = tabsGroup.find(tabGroup => tabGroup.id === tab.tabGroupId);
     const tabFound = tabGroup.tabs.find(currentTab => currentTab.id === tab.id);
     tabFound.isSelected = true;
+    await this.setTabsGroup(tabsGroup);
+  }
+
+  async detachBrowserTab(browserTabId: number) {
+    const tabsGroup = await this.getTabsGroup();
+    const tabGroup = tabsGroup.find(tabGroup => tabGroup.tabId === browserTabId);
+    tabGroup.tabId = undefined;
     await this.setTabsGroup(tabsGroup);
   }
 

--- a/test/storage.spec.ts
+++ b/test/storage.spec.ts
@@ -71,7 +71,7 @@ it('get tab group by browser tab id', async () => {
 });
 
 it('return true if found one tab group with the id of the browser tab', async () => {
-  const isBrowserTabAssigned = await storage.isBrowserTabAssigned(1);
+  const isBrowserTabAssigned = await storage.isBrowserTabAttached(1);
   expect(isBrowserTabAssigned).to.be.true;
 });
 
@@ -88,6 +88,12 @@ it('delete all the tabs group', async () => {
   await storage.clear();
   const tabsGroup = await storage.getTabsGroup();
   expect(tabsGroup).to.be.empty;
+});
+
+it('detach browser tab of a tab group', async () => {
+  await storage.detachBrowserTab(1);
+  const isAttach = await storage.isBrowserTabAttached(1);
+  expect(isAttach).to.be.false;
 });
 
 afterEach(async () => {


### PR DESCRIPTION
When the user closes a browser tab that has a tab group, the tab group is detached for the browser tab.

Other changes:

- The property CREATE_TAB of the enum MessageType was renamed to GET_TAB_ID. This is a better name to this property because when a message is sent with the value of that property, the receiver returns the id of one tab, don't create one.