### PR TITLE
Improve the design and the insolation of the tab bar and add the Add option

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -23,7 +23,7 @@ chrome.webNavigation.onCommitted.addListener(async details => {
   if (details.frameId !== 0) return;
   const tabGroup = await storage.getTabGroupByTabId(details.tabId);
   if (tabGroup) {
-    chrome.tabs.executeScript(tabGroup.tabId, { file: 'content-script.js'});
+    chrome.tabs.executeScript(tabGroup.tabId, { file: 'content-script.js' });
   }
 });
 

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -2,32 +2,54 @@ import * as React from 'react';
 import { Tab } from './tab';
 import '../../styles/tab-bar/tab-bar.css';
 import { MessageType } from '../../enums/message-type';
-import { Storage, LocalStorage, TabGroup } from '../../storage';
+import * as storage from '../../storage';
 import { IconButton } from 'office-ui-fabric-react';
 
 export class TabBar extends React.Component {
 
-  state: { tabGroup: TabGroup | any }
-  storage: Storage
+  state: { tabGroup: storage.TabGroup }
+  storage: storage.Storage
 
   constructor(props: any) {
     super(props);
-    this.state = { tabGroup: { tabs: [] } };
-    this.storage = new Storage(new LocalStorage());
+    this.state = { tabGroup: storage.TabGroup.emptyTabGroup };
+    this.storage = new storage.Storage(new storage.LocalStorage());
   }
 
   componentDidMount = async () => {
-    const tabId = await this.getTabId();
-    const tabGroup = await this.storage.getTabGroupByTabId(tabId);
-    this.setState({ tabGroup });
+    await this.updateTabGroup();
   }
 
-  private getTabId(): Promise<number> {
+  getTabId(): Promise<number> {
     return new Promise((resolve, reject) => {
       chrome.runtime.sendMessage({ type: MessageType.GET_TAB_ID }, tabId => {
         resolve(tabId);
       });
     });
+  }
+
+  handleAddOptionClick = async () => {
+    const tab = new storage.Tab('Nueva pestaña', 'https://www.google.com', this.state.tabGroup.id);
+    const selectedTab = this.getSelectedOffice();
+    await this.storage.addTab(tab);
+    await this.storage.selectTab(selectedTab, false);
+    await this.updateTabGroup();
+    chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab } });
+  }
+
+  handleUnselectTab = async () => {
+    const tab = this.getSelectedOffice();
+    await this.storage.selectTab(tab, false);
+  }
+
+  getSelectedOffice() {
+    return this.state.tabGroup.tabs.find(tab => tab.isSelected);
+  }
+
+  async updateTabGroup() {
+    const tabId = await this.getTabId();
+    const tabGroup = await this.storage.getTabGroupByTabId(tabId);
+    this.setState({ tabGroup });
   }
 
   render() {
@@ -36,12 +58,12 @@ export class TabBar extends React.Component {
         <div className='main-pane'>
           <div className='tabs-list'>
             {
-              this.state.tabGroup.tabs.map((tab: any) => {
-                return <Tab tab={tab} />;
+              this.state.tabGroup.tabs.map(tab => {
+                return <Tab key={tab.id} tab={tab} onUnselectTab={this.handleUnselectTab}/>;
               })
             }
-            <IconButton iconProps={({ iconName: 'add'})} className='add-option'/>
           </div>
+          <IconButton iconProps={({ iconName: 'add' })} className='add-option' onClick={this.handleAddOptionClick} />
         </div>
       </div>
     );

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -3,6 +3,7 @@ import { Tab } from './tab';
 import '../../styles/tab-bar/tab-bar.css';
 import { MessageType } from '../../enums/message-type';
 import { Storage, LocalStorage, TabGroup } from '../../storage';
+import { IconButton } from 'office-ui-fabric-react';
 
 export class TabBar extends React.Component {
 
@@ -32,11 +33,16 @@ export class TabBar extends React.Component {
   render() {
     return (
       <div className='tab-bar'>
-        {
-          this.state.tabGroup.tabs.map((tab: any) => {
-            return (<Tab tab={tab} />);
-          })
-        }
+        <div className='main-pane'>
+          <div className='tabs-list'>
+            {
+              this.state.tabGroup.tabs.map((tab: any) => {
+                return <Tab tab={tab} />;
+              })
+            }
+            <IconButton iconProps={({ iconName: 'add'})} className='add-option'/>
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/components/tab-bar/tab.tsx
+++ b/src/components/tab-bar/tab.tsx
@@ -11,19 +11,17 @@ export class Tab extends React.Component<props> {
 
   storage: Storage = new Storage(new LocalStorage());
 
-  private handleClick = async () => {
+  handleClick = async () => {
     const tab = this.props.tab;
     this.storage.selectTab(tab);
     chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab: tab } });
   }
 
   render() {
-    let div = {};
-    if (!this.props.tab.isSelected) {
-      div = (<div className='tab' onClick={this.handleClick}>{this.props.tab.name}</div>);
+    if (this.props.tab.isSelected) {
+      return <div className='tab selected-tab' onClick={this.handleClick}>{this.props.tab.name}</div>;
     } else {
-      div = (<div className='tab2' onClick={this.handleClick}>{this.props.tab.name}</div>);
+      return <div className='tab' onClick={this.handleClick}>{this.props.tab.name}</div>;
     }
-    return div;
   }
 }

--- a/src/components/tab-bar/tab.tsx
+++ b/src/components/tab-bar/tab.tsx
@@ -1,20 +1,22 @@
 import * as React from 'react';
 import '../../styles/tab-bar/tab.css';
 import { MessageType } from '../../enums/message-type';
-import { Storage, LocalStorage} from '../../storage';
+import * as storage from '../../storage';
 
 interface props {
-  tab: any
+  tab: storage.Tab,
+  onUnselectTab: () => void
 }
 
 export class Tab extends React.Component<props> {
 
-  storage: Storage = new Storage(new LocalStorage());
+  storage = new storage.Storage(new storage.LocalStorage());
 
   handleClick = async () => {
+    await this.props.onUnselectTab();
     const tab = this.props.tab;
-    this.storage.selectTab(tab);
-    chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab: tab } });
+    await this.storage.selectTab(tab, true);
+    chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab } });
   }
 
   render() {

--- a/src/content-script.css
+++ b/src/content-script.css
@@ -1,11 +1,8 @@
-:root {
-  --tab-bar-height: 32px;
-}
-
-.tab-group {
-  all: initial;
+.iframe {
+  height: 56px;
   width: 100vw;
   position: fixed;
   bottom: 0px;
   z-index: 5000;
+  border: none;
 }

--- a/src/content-script.css
+++ b/src/content-script.css
@@ -1,5 +1,5 @@
 :root {
-  --tab-bar-height: 24px;
+  --tab-bar-height: 32px;
 }
 
 .tab-group {
@@ -7,6 +7,5 @@
   width: 100vw;
   position: fixed;
   bottom: 0px;
-  background-color: red;
   z-index: 5000;
 }

--- a/src/content-script.tsx
+++ b/src/content-script.tsx
@@ -1,13 +1,6 @@
-import * as React from 'react';
-import * as ReactDom from 'react-dom';
-import { TabBar } from './components/tab-bar/tab-bar';
 import './content-script.css';
-import { initializeIcons } from '@uifabric/icons';
-initializeIcons();
 
-const body = document.body;
-const tabGroup = document.createElement('div');
-tabGroup.classList.add('tab-group');
-
-body.appendChild(tabGroup);
-ReactDom.render(<TabBar/>, tabGroup);
+const iframe = document.createElement('iframe');
+iframe.classList.add('iframe');
+document.body.append(iframe);
+iframe.src = chrome.runtime.getURL('tab-bar-page.html');

--- a/src/content-script.tsx
+++ b/src/content-script.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import * as ReactDom from 'react-dom';
 import { TabBar } from './components/tab-bar/tab-bar';
 import './content-script.css';
+import { initializeIcons } from '@uifabric/icons';
+initializeIcons();
 
 const body = document.body;
 const tabGroup = document.createElement('div');

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,6 +4,9 @@
   "description": "Group several tabs within only one tab",
   "manifest_version": 2,
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "web_accessible_resources": [
+    "tab-bar-page.html"
+  ],
   "permissions": [
     "activeTab",
     "webNavigation",

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -19,6 +19,14 @@ export class Storage {
     await this.storage.setTabsGroup(tabsGroup);
   }
 
+  async addTab(tab: Tab) {
+    this.settingDefaultTab(tab);
+    const tabGroup = await this.getTabGroup(tab.tabGroupId);
+    tabGroup.tabs.push(tab);
+    await this.updateTabGroup(tabGroup);
+
+  }
+
   async getTabsGroup(): Promise<TabGroup[]> {
     return this.storage.getTabsGroup('tabsGroup');
   }
@@ -41,11 +49,11 @@ export class Storage {
     return isAssigned;
   }
 
-  async selectTab(tab: Tab) {
+  async selectTab(tab: Tab, select: boolean) {
     const tabsGroup = await this.getTabsGroup();
     const tabGroup = tabsGroup.find(tabGroup => tabGroup.id === tab.tabGroupId);
     const tabFound = tabGroup.tabs.find(currentTab => currentTab.id === tab.id);
-    tabFound.isSelected = true;
+    tabFound.isSelected = select;
     await this.updateTabGroup(tabGroup);
   }
 

--- a/src/storage/tab-group.ts
+++ b/src/storage/tab-group.ts
@@ -2,12 +2,14 @@ import { Tab } from './tab';
 
 export class TabGroup {
 
+  static emptyTabGroup = new TabGroup('', 0, [], '');
+
   id: string;
   tabId: number;
   name: string;
   tabs: Tab[];
 
-  constructor(name: string, tabId: number, tabs: Tab[], id?: string) {
+  constructor(name?: string, tabId?: number, tabs?: Tab[], id?: string) {
     this.id = id;
     this.name = name;
     this.tabId = tabId;

--- a/src/storage/tab.ts
+++ b/src/storage/tab.ts
@@ -6,8 +6,9 @@ export class Tab {
   url: string;
   isSelected: boolean
 
-  constructor(name: string, url: string) {
+  constructor(name: string, url: string, tabGroupId?: string) {
     this.name = name;
     this.url = url;
+    this.tabGroupId = tabGroupId;
   }
 }

--- a/src/styles/tab-bar/tab-bar.css
+++ b/src/styles/tab-bar/tab-bar.css
@@ -1,10 +1,12 @@
 .tab-bar {
+  --tab-bar-height: 32px;
   display: flex;
   height: var(--tab-bar-height);
   background-color: white;
   margin: 12px 28px 12px 12px;
   border-radius: 4px;
   box-shadow: 0px 1px 3px gray;
+  overflow-y: hidden;
 }
 
 .add-option {

--- a/src/styles/tab-bar/tab-bar.css
+++ b/src/styles/tab-bar/tab-bar.css
@@ -3,10 +3,18 @@
   display: flex;
   height: var(--tab-bar-height);
   background-color: white;
-  margin: 12px 28px 12px 12px;
+  margin: 12px 27px 12px 12px;
   border-radius: 4px;
   box-shadow: 0px 1px 3px gray;
   overflow-y: hidden;
+}
+
+.tabs-list div:first-child {
+  border-radius: 4px 0px 0px 4px;
+}
+
+.main-pane {
+  display: flex;
 }
 
 .add-option {
@@ -15,4 +23,8 @@
   font-size: var(--tab-bar-height);
   color: black;
   margin-left: 8px;
+}
+
+* {
+  box-sizing: border-box;
 }

--- a/src/styles/tab-bar/tab-bar.css
+++ b/src/styles/tab-bar/tab-bar.css
@@ -1,4 +1,16 @@
 .tab-bar {
+  display: flex;
   height: var(--tab-bar-height);
-  background-color: lightgray;
+  background-color: white;
+  margin: 12px 28px 12px 12px;
+  border-radius: 4px;
+  box-shadow: 0px 1px 3px gray;
+}
+
+.add-option {
+  width: var(--tab-bar-height);
+  height: var(--tab-bar-height);
+  font-size: var(--tab-bar-height);
+  color: black;
+  margin-left: 8px;
 }

--- a/src/styles/tab-bar/tab.css
+++ b/src/styles/tab-bar/tab.css
@@ -1,10 +1,14 @@
 .tab {
+  display: inline-block;
   width: 150px;
   height: var(--tab-bar-height);
-  display: inline-block;
-  border-radius: 4px 0px 0px 4px;
   padding: 6px;
   overflow-y: hidden;
+  cursor: default;
+}
+
+.tab:hover {
+  background-color: lightgray;
 }
 
 .selected-tab {

--- a/src/styles/tab-bar/tab.css
+++ b/src/styles/tab-bar/tab.css
@@ -1,15 +1,11 @@
 .tab {
   width: 150px;
   height: var(--tab-bar-height);
-  background-color: aliceblue;
   display: inline-block;
-  border-right: 1px solid black;
+  border-radius: 4px 0px 0px 4px;
+  padding: 6px;
 }
 
-.tab2 {
-  width: 150px;
-  height: var(--tab-bar-height);
-  background-color: red;
-  display: inline-block;
-  border-right: 1px solid black;
+.selected-tab {
+  border-bottom: 2px solid blue;
 }

--- a/src/styles/tab-bar/tab.css
+++ b/src/styles/tab-bar/tab.css
@@ -4,6 +4,7 @@
   display: inline-block;
   border-radius: 4px 0px 0px 4px;
   padding: 6px;
+  overflow-y: hidden;
 }
 
 .selected-tab {

--- a/src/tab-bar-page.tsx
+++ b/src/tab-bar-page.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import { TabBar } from './components/tab-bar/tab-bar';
+import { initializeIcons } from '@uifabric/icons';
+initializeIcons();
+
+const root = document.createElement('div');
+document.body.appendChild(root);
+ReactDom.render(<TabBar/>, root);

--- a/test/storage.spec.ts
+++ b/test/storage.spec.ts
@@ -75,7 +75,7 @@ it('return true if found one tab group with the id of the browser tab', async ()
 
 it('select the tab passed as argument', async () => {
   const { tabs } = await storage.getTabGroup('1');
-  await storage.selectTab(tabs[0]);
+  await storage.selectTab(tabs[0], true);
   {
     const { tabs } = await storage.getTabGroup('1');
     expect(tabs[0].isSelected).to.be.true;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,8 @@ module.exports = {
     background: './src/background.ts',
     'content-script': './src/content-script.tsx',
     'popup-root': './src/popup-root.tsx',
-    'index-root': './src/index-root.tsx'
+    'index-root': './src/index-root.tsx',
+    'tab-bar-page': './src/tab-bar-page.tsx'
   },
   output: {
     filename: '[name].js'
@@ -32,6 +33,10 @@ module.exports = {
       filename: 'index.html',
       chunks: ['index-root'],
       title: 'Index'
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'tab-bar-page.html',
+      chunks: ['tab-bar-page']
     })
   ],
   module: {


### PR DESCRIPTION
#### Change the method of insolation

The method used to insolate the tab bar was changed. Now we use iframe instead of the "all" property. For more details about this decision see the issue #6.

#### Improve the design of the tab bar

The design of the tab bar was improved:

Old
![old tab bar](https://user-images.githubusercontent.com/21043752/72197008-fb556000-33f2-11ea-9b17-811ada3516c2.png)

New
![new tab bar](https://user-images.githubusercontent.com/21043752/72197017-0dcf9980-33f3-11ea-914d-4c581d270aa5.png)

See the commit 31a239d32b6a5e94a0a20041be6f91870a068bdd for more details.

#### Add option

Add the Add option. This option lets the user add new tabs to the tab bar.

## QA

1. Compile the extension `npm run build`
2. Open the tab bar page. To open this page, open the popup of the tab bar and click in the button Open page.
3. Open a tab group
4. In the new page opened do click in the Add option of the tab bar (+). If a new tab is added to the tab bar then all work well.
