### PR TITLE
Improve the layout of the tab bar and add the close option

### DIFF
--- a/src/components/index/tab-group.tsx
+++ b/src/components/index/tab-group.tsx
@@ -26,7 +26,7 @@ export function TabGroup({ tabGroup }: { tabGroup: Storage.TabGroup }) {
     });
   }
 
-  async function getSelectedTab() {
+  function getSelectedTab() {
     return tabGroup.tabs.find(tab => tab.isSelected);
   }
 

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -3,7 +3,7 @@ import { Tab } from './tab';
 import '../../styles/tab-bar/tab-bar.css';
 import { MessageType } from '../../enums/message-type';
 import * as Storage from '../../storage';
-import { IconButton } from 'office-ui-fabric-react';
+import { Icon } from 'office-ui-fabric-react';
 import { Message } from '../../message';
 
 export function TabBar() {
@@ -27,14 +27,13 @@ export function TabBar() {
     });
   }
 
-  async function handleAddOptionClick() {
+  async function handleAddTab() {
     const tab = new Storage.Tab(
       undefined, 'Nueva pestaña', 'https://www.google.com',
       tabGroup.id, true, 'https://www.google.com/favicon.ico'
     );
-    const selectedTab = getSelectedTab();
     await storage.addTab(tab);
-    await storage.selectTab(selectedTab, false);
+    await handleUnselectTab();
     await updateTabGroup();
     chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab } });
   }
@@ -124,7 +123,7 @@ export function TabBar() {
             })
           }
         </div>
-        <IconButton iconProps={({ iconName: 'add' })} className='add-option' onClick={handleAddOptionClick} />
+        <Icon iconName='add' className='icon' onClick={handleAddTab}/>
       </div>
     </div>
   );

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -38,6 +38,12 @@ export function TabBar() {
     chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab } });
   }
 
+  async function handleCloseTabBar() {
+    await storage.detachBrowserTab(tabGroup.tabId);
+    const tab = getSelectedTab();
+    chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab } });
+  }
+
   async function handleUnselectTab() {
     const tab = getSelectedTab();
     await storage.selectTab(tab, false);
@@ -124,6 +130,9 @@ export function TabBar() {
           }
         </div>
         <Icon iconName='add' className='icon' onClick={handleAddTab}/>
+      </div>
+      <div className='options'>
+        <Icon iconName='cancel' className='icon' onClick={handleCloseTabBar}/>
       </div>
     </div>
   );

--- a/src/styles/tab-bar/tab-bar.css
+++ b/src/styles/tab-bar/tab-bar.css
@@ -17,12 +17,21 @@
   display: flex;
 }
 
-.add-option {
-  width: var(--height);
-  height: var(--height);
-  font-size: var(--height);
+
+.icon {
+  width: 24px;
+  font-size: 15px;
+  text-align: center;
+  line-height: 24px;
+  cursor: default;
   color: black;
-  margin-left: 8px;
+  border-radius: 2px;
+  margin: 0px 8px;
+}
+
+.icon:hover {
+  color: blue;
+  background-color: #DDDDDD;
 }
 
 * {

--- a/src/styles/tab-bar/tab-bar.css
+++ b/src/styles/tab-bar/tab-bar.css
@@ -1,22 +1,36 @@
 .tab-bar {
   --height: 32px;
-  display: flex;
+  display: grid;
   height: var(--height);
   background-color: white;
+  grid-template-columns: calc(100% - 36px) 36px;
   margin: 12px 27px 12px 12px;
   border-radius: 4px;
   box-shadow: 0px 1px 3px gray;
-  overflow-y: hidden;
+}
+
+.main-pane {
+  display: flex;
+  align-items: center;
+}
+
+.tabs-list {
+  max-width: calc(100% - 32px);
+  display: flex;
+  overflow: hidden;
 }
 
 .tabs-list div:first-child {
   border-radius: 4px 0px 0px 4px;
 }
 
-.main-pane {
+.options {
+  width: 32px;
   display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-right: 4px;
 }
-
 
 .icon {
   width: 24px;
@@ -26,7 +40,7 @@
   cursor: default;
   color: black;
   border-radius: 2px;
-  margin: 0px 8px;
+  margin: 0px 4px;
 }
 
 .icon:hover {

--- a/src/styles/tab-bar/tab.css
+++ b/src/styles/tab-bar/tab.css
@@ -1,5 +1,6 @@
 .tab {
-  display: inline-grid;
+  display: grid;
+  flex: 1 1;
   width: 180px;
   height: var(--height);
   grid-template-columns: var(--height) auto var(--height);
@@ -25,11 +26,10 @@
 }
 
 .title {
-  width: 108px;
+  width: 100%;
   height: 16px;
   overflow: hidden;
   justify-self: flex-start;
-  margin-left: 2px;
 }
 
 .close {


### PR DESCRIPTION
Improve the design of the tab bar. Now when there isn't enough space in the tab bar to show the tabs, the tabs starting to shrinking until they reach the with of 72 px. When this size is reached, the tabs overflow the tab bar and the lastest tabs are hidden.

Also, add the close option. When the user clicks in this option, the tab bar is detached from the browser tab.

For other changes, see the commits.

## Images

Before

![before tab bar design](https://user-images.githubusercontent.com/21043752/74202358-a0f22e00-4c42-11ea-972b-9770f18a976c.png)

After

![after tab bar design](https://user-images.githubusercontent.com/21043752/74202366-a9e2ff80-4c42-11ea-973e-084f05c34924.png)


## QA

1. Build the project `npm run build`.
2. Open the browser.
3. Create a new tab group with the popup.
4. Add a lot of tabs. When there isn't enough space in the tab bar, the tabs must start to shrink. When the size of the tabs be of 72 px, the tabs must overflow the tab bar and the lastest tabs must be hidden.
5. Close the tab bar clicking the close button. The tab bar must be removed from the page.
