### PR TITLE
Add a progress bar and a tooltip to the tabs

### DIFF
--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -10,6 +10,7 @@ export function TabBar() {
 
   const [tabGroup, setTabGroup] = React.useState(Storage.TabGroup.emptyTabGroup);
   const storage = new Storage.Storage(new Storage.LocalStorage());
+  const [isLoading, setLoading] = React.useState(true);
 
   React.useEffect(() => {
     chrome.runtime.onMessage.addListener(updateTab);
@@ -104,6 +105,7 @@ export function TabBar() {
     tab.url = arg.url;
     tab.favIconUrl = arg.favIconUrl;
     await storage.updateTab(tab);
+    setLoading(false);
     setTabGroup(tabGroup);
   }
 
@@ -123,6 +125,7 @@ export function TabBar() {
                 <Tab
                   key={tab.id}
                   tab={tab}
+                  isLoading={isLoading && tab.isSelected}
                   onUnselectTab={handleUnselectTab}
                   onCloseTab={handleCloseTab} />
               );

--- a/src/components/tab-bar/tab.tsx
+++ b/src/components/tab-bar/tab.tsx
@@ -1,23 +1,24 @@
 import * as React from 'react';
 import '../../styles/tab-bar/tab.css';
 import { MessageType } from '../../enums/message-type';
-import { Icon } from 'office-ui-fabric-react';
+import { Icon, Spinner, SpinnerSize, Shimmer } from 'office-ui-fabric-react';
 import * as Storage from '../../storage';
 
 interface props {
-  tab: Storage.Tab,
-  onUnselectTab: () => void,
-  onCloseTab: (tab: Storage.Tab) => void
+  tab: Storage.Tab;
+  isLoading: boolean;
+  onUnselectTab: () => void;
+  onCloseTab: (tab: Storage.Tab) => void;
 }
 
-export function Tab({ tab, onUnselectTab, onCloseTab }: props) {
+export function Tab({ tab, onUnselectTab, onCloseTab, isLoading }: props) {
 
   const storage = new Storage.Storage(new Storage.LocalStorage());
 
   async function handleTabClick() {
     await onUnselectTab();
     await storage.selectTab(tab, true);
-    chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab } }); 
+    chrome.runtime.sendMessage({ type: MessageType.NAVIGATE, arg: { tab } });
   }
 
   function handleCloseTab(event: any) {
@@ -29,8 +30,17 @@ export function Tab({ tab, onUnselectTab, onCloseTab }: props) {
 
   return (
     <div className={className} onClick={handleTabClick}>
-      <img className='favicon' title={tab.name} src={tab.favIconUrl} />
-      <div className='title' title={tab.name}>{tab.name}</div>
+      { isLoading &&
+        <React.Fragment>
+          <Spinner size={SpinnerSize.small}/>
+          <Shimmer width='100px'/>
+        </React.Fragment>
+      } { !isLoading && 
+        <React.Fragment>
+          <img className='favicon' title={tab.name} src={tab.favIconUrl}/>
+          <div className='title' title={tab.name}>{tab.name}</div>
+        </React.Fragment>
+      }
       <Icon iconName='cancel' className='close' onClick={handleCloseTab} />
     </div>
   );

--- a/src/components/tab-bar/tab.tsx
+++ b/src/components/tab-bar/tab.tsx
@@ -29,8 +29,8 @@ export function Tab({ tab, onUnselectTab, onCloseTab }: props) {
 
   return (
     <div className={className} onClick={handleTabClick}>
-      <img className='favicon' src={tab.favIconUrl} />
-      <div className='title'>{tab.name}</div>
+      <img className='favicon' title={tab.name} src={tab.favIconUrl} />
+      <div className='title' title={tab.name}>{tab.name}</div>
       <Icon iconName='cancel' className='close' onClick={handleCloseTab} />
     </div>
   );

--- a/src/styles/tab-bar/tab-bar.css
+++ b/src/styles/tab-bar/tab-bar.css
@@ -20,7 +20,7 @@
   overflow: hidden;
 }
 
-.tabs-list div:first-child {
+.tabs-list .tab:first-child {
   border-radius: 4px 0px 0px 4px;
 }
 

--- a/src/styles/tab-bar/tab.css
+++ b/src/styles/tab-bar/tab.css
@@ -23,6 +23,7 @@
   width: 16px;
   height: 16px;
   background-color: aliceblue;
+  overflow: hidden;
 }
 
 .title {


### PR DESCRIPTION
[Ticket #4](https://trello.com/c/I1XnO94G), [Ticket #6](https://trello.com/c/t7hproQm)

Add a progress bar to the tabs of the tab bar. This progress bar is shown when the selected tab is loading. And also, add a tooltip that shows the full title of the tabs when the mouse is over them.

Progress bar

![progress bar](https://user-images.githubusercontent.com/21043752/74386989-c8293680-4dcd-11ea-80e9-257e2894662c.png)


## QA

Test the progress bar

1. Build the extension `npm run build`.
2. Open the browser.
3. Create a new tab bar using the popup of the extension.
4. Navigate to a page like Facebook or Twitter. When the page is loading you must see the progress bar in the selected tab.

Test the tooltip

5. Pass the mouse over one tab. The tooltip must show the full title of the tab. 