### PR TITLE
Fix a problem that updates all opened tabs bars with the same data 

### DIFF
--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -8,19 +8,6 @@ export function Popup() {
   const storage = new Storage(new LocalStorage());
   const [name, setName] = React.useState('');
 
-  React.useEffect(() => {
-    chrome.tabs.onUpdated.addListener(onUpdatedTab);
-    return () => {
-      chrome.tabs.onUpdated.removeListener(onUpdatedTab);
-    };
-  });
-
-  function onUpdatedTab(tabId: Number, changeInfo: any, tab: chrome.tabs.Tab) {
-    if (changeInfo.status === 'complete') {
-      chrome.tabs.executeScript({ file: 'content-script.js' });
-    }
-  }
-
   function handleInputChange(event: any) {
     setName(event.target.value);
   }
@@ -38,20 +25,19 @@ export function Popup() {
   }
 
   async function createTabGroup(browserTab: chrome.tabs.Tab) {
+    
     const isValidUrl = browserTab.url !== 'edge://newtab/';
     const url = isValidUrl ? browserTab.url : 'https://www.google.com.do';
+    
     const tab = new Tab(undefined, browserTab.title, url);
     const tabGroup = new TabGroup(name, browserTab.id, [tab]);
     await storage.addTabGroup(tabGroup);
-    insertTabBar(isValidUrl, url);
-  }
 
-  function insertTabBar(isValidUrl: boolean, url: string) {
-    if (isValidUrl) {
-      chrome.tabs.executeScript({ file: 'content-script.js' });
-    } else {
-      chrome.tabs.update({ url: 'https://www.google.com.do' });
-    }
+    // The tab bar is inserted from the background script when the listener
+    // chrome.webNavigation.onCommitted is triggered. This listener is triggered
+    // when the page is updating.
+    chrome.tabs.update({ url });
+    
     window.close();
   }
 

--- a/src/tab-bar-page.tsx
+++ b/src/tab-bar-page.tsx
@@ -1,9 +1,17 @@
 import * as React from 'react';
 import * as ReactDom from 'react-dom';
-import { TabBar } from './components/tab-bar/tab-bar';
+import getBrowserTabId from './utils/getBrowserTabId';
 import { initializeIcons } from '@uifabric/icons';
+import { TabBar } from './components/tab-bar/tab-bar';
+import { Storage, LocalStorage, TabGroup } from './storage';
+
 initializeIcons();
 
-const root = document.createElement('div');
-document.body.appendChild(root);
-ReactDom.render(<TabBar/>, root);
+(async () => {
+  const tabId = await getBrowserTabId();
+  const storage = new Storage(new LocalStorage());
+  const tabGroup = await storage.getTabGroupByTabId(tabId);
+  const root = document.createElement('div');
+  document.body.appendChild(root);
+  ReactDom.render(<TabBar tabGroup={tabGroup}/>, root);
+})();


### PR DESCRIPTION
When the browser tab updates, the background script sends a message to the tab bar of the current page to update the title, favicon, and URL of the selected tab of it. But this message also was sent to the tabs bars of the other pages, updating the other tabs bars with the same data of the tab bar of the current page.

This problem was going on for a bug in the chrome.tabs.sendMessage method. This method must send the message to a specific tab, but it sends the message to all tabs. This problem is explained better in this [question](https://stackoverflow.com/questions/32508008/chrome-extension-chrome-tabs-sendmessage-is-sending-the-message-to-all-tabs-eve) of Stack Overflow:

This problem was solved comparing the id received in the message with the id of the tab group in the tabs bars. The data of the tab bar is updated just if both ids are equals.

#### Other changes

Improve the code of the tab bar.

## QA

1. Build the extension `npm run build`.
2. Open the browser.
3. Create a new tab group using the popup of the extension.
4. Open a new browser tab and create another tab group.
5. Navigate to different pages in both browser tabs.
6. Refresh one browser tab and make sure that another browser tab doesn't have the same data that the updated tab.