### PR TITLE
Redesign the popup

### DIFF
--- a/src/components/popup/option.tsx
+++ b/src/components/popup/option.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Icon } from 'office-ui-fabric-react';
+import '../../styles/popup/option.css';
+
+interface props {
+  icon: string,
+  title: string,
+  onClick?: () => void
+}
+
+export function Option({ icon, title, onClick }: props) {
+  return (
+    <div className='option' onClick={onClick}>
+      <Icon className='icon' iconName={icon}/>
+      <div className='name'>{title}</div>
+    </div>
+  );
+}

--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import '../../styles/popup/popup.css';
-import { TextField, PrimaryButton } from 'office-ui-fabric-react';
+import { Option } from './option';
 import { Storage, LocalStorage, TabGroup, Tab } from '../../storage';
 
 export function Popup() {
@@ -54,10 +54,12 @@ export function Popup() {
 
   return (
     <div className='popup'>
-      <div className='title'>Crear nuevo grupo de pestañas</div>
-      <TextField className='text-field' placeholder='Nombre' value={name} onChange={handleInputChange} />
-      <PrimaryButton className='button' text='Crear grupo' onClick={handleButtonClick} />
-      <PrimaryButton className='button' text='Open page' onClick={handleOpenPageButtonClick} />
+      <div className='title'>Grupo de pestañas</div>
+      <div className='options'>
+        <Option icon="addin" title="Create tab group" />
+        <Option icon="openinnewtab" title="Open tab group page" onClick={handleOpenPageButtonClick}/>
+        <Option icon="pageadd" title="Add page to a tab group"/>
+      </div>
     </div>
   );
 }

--- a/src/popup-root.tsx
+++ b/src/popup-root.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import * as ReactDom from 'react-dom';
+import { initializeIcons } from '@uifabric/icons';
 import { Popup } from './components/popup/popup';
+
+initializeIcons();
 
 const root = document.createElement('div');
 document.body.prepend(root);

--- a/src/styles/popup/option.css
+++ b/src/styles/popup/option.css
@@ -1,0 +1,24 @@
+.option {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  margin: 4px auto;
+  padding: 4px 8px;
+  cursor: default;
+}
+
+.option:hover {
+  background-color: #F5F5F5;
+}
+
+.name {
+  font-size: 15px;
+}
+
+.icon {
+  width: 24px;
+  line-height: 24px;
+  font-size: 15px;
+  text-align: center;
+  cursor: default;
+  border-radius: 2px;
+}

--- a/src/styles/popup/popup.css
+++ b/src/styles/popup/popup.css
@@ -1,19 +1,15 @@
 .popup {
-  padding: 16px;
+  width: 260px;
+  padding: 12px 8px;
 }
 
 .title {
-  font-size: 17px;
+  font-size: 15px;
   font-weight: 600;
   color: black;
+  margin-left: 12px;
 }
 
-.text-field {
-  width: 250px;
+.options {
   margin-top: 20px;
-}
-
-.button {
-  display: block;
-  margin: 16px 0px 0px auto;
 }

--- a/src/tab-bar-page.tsx
+++ b/src/tab-bar-page.tsx
@@ -3,7 +3,7 @@ import * as ReactDom from 'react-dom';
 import getBrowserTabId from './utils/getBrowserTabId';
 import { initializeIcons } from '@uifabric/icons';
 import { TabBar } from './components/tab-bar/tab-bar';
-import { Storage, LocalStorage, TabGroup } from './storage';
+import { Storage, LocalStorage } from './storage';
 
 initializeIcons();
 


### PR DESCRIPTION
[Ticket #7](https://trello.com/c/7IGs0tQt)

Now the popup has three options: "Create tab group", "Open tab group
page", "Add page to a tab group".

![Grupo 2](https://user-images.githubusercontent.com/21043752/75736018-80157980-5cd2-11ea-8fa5-9a8eb19f4cd7.png)

## QA

1. Build the extension `npm run build`.
2. Open the browser.
3. Open the popup. The popup must have the new design.
4. Hover the mouse over the options. The color of the options must change to light gray.
5. Click the "Open tab group page" option. The tab group page must open.
